### PR TITLE
temp change to LMP version 

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <!-- end::liberty-maven-plugin[] -->
         </plugins>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <!-- end::liberty-maven-plugin[] -->
         </plugins>


### PR DESCRIPTION
Issue came to light because of GM Candidate testing and automation failure:
```
[ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.2.2:dev (default-cli) on project guide-rest-client-reactjs: null: MojoExecutionException: NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```
- cannot install features because the 20.0.0.9 features are not on Maven Central.
